### PR TITLE
atoi does not work on hex, convert to (uint16_t)strtol()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -154,10 +154,10 @@ int main(int argc, char** argv)
 				page_limit = atoi(optarg);
 				break;
 			case 'v': // vid
-				vid = atoi(optarg);
+				vid = (uint16_t)strtol(optarg, NULL, 0);
 				break;
-			case 'p': // vid
-				pid = atoi(optarg);
+			case 'p': // pid
+				pid = (uint16_t)strtol(optarg, NULL, 0);
 				break;
 			case 'P':
 				if (port != NULL) {


### PR DESCRIPTION
The -p and -v parameters make it sound as you could pass a hexadecimal
value along. That however causes atoi to fail and pid/vid are set to 0.
Using strol allows a wide range of values to be passed along, but needs
to be cast back to a 16bit value. A check could be added to verify the
input is within range.

Signed-off-by: Olliver Schinagl oliver@schinagl.com
