### PR TITLE
Resync

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ All input files are autodetected.
 * Windows:
   *  cdc acm driver
 
-## Building:
+## Building
 
-From git repository first run:
+### From a git repository
+
+At first do this, then follow the tarball instructions
 
 ```
 $ autoreconf --install
+```
 
+### From a tarball
+
+```
 $ ./configure
 $ make
 $ make install

--- a/src/ols.c
+++ b/src/ols.c
@@ -138,7 +138,7 @@ int OLS_RunSelftest(struct ols_t *ols)
 
 	retry=0;
 	while (1) {
-		res = serial_read(ols->fd, &status, 1);
+		res = serial_read(ols->fd, &status, 1, 100);
 
 		if (res < 1) {
 			retry ++;
@@ -194,7 +194,7 @@ int OLS_GetStatus(struct ols_t *ols)
 		return -2;
 	}
 
-	res = serial_read(ols->fd, &status, 1);
+	res = serial_read(ols->fd, &status, 1, 100);
 
 	if (res != 1) {
 		printf("Error reading OLS status\n");
@@ -221,7 +221,7 @@ int OLS_GetID(struct ols_t *ols)
 		return -2;
 	}
 
-	res = serial_read(ols->fd, ret, 7);
+	res = serial_read(ols->fd, ret, 7, 10);
 	if (res != 7) {
 		printf("Error reading OLS id\n");
 		return -1;
@@ -290,7 +290,7 @@ int OLS_GetFlashID(struct ols_t *ols) {
 		return -2;
 	}
 
-	res = serial_read(ols->fd, ret, 4);
+	res = serial_read(ols->fd, ret, 4, 10);
 	if (res != 4) {
 		printf("Error reading JEDEC ID\n");
 		return -1;
@@ -343,7 +343,7 @@ int OLS_FlashErase(struct ols_t *ols)
 	printf("Chip erase ... ");
 
 	while (1) {
-		res = serial_read(ols->fd, &status, 1);
+		res = serial_read(ols->fd, &status, 1, 100);
 
 		if (res <1) {
 			retry ++;
@@ -406,7 +406,7 @@ int OLS_FlashRead(struct ols_t *ols, uint16_t page, uint8_t *buf)
 		return -2;
 	}
 
-	res = serial_read(ols->fd, buf, ols->flash->page_size);
+	res = serial_read(ols->fd, buf, ols->flash->page_size, 100);
 
 	if (res == ols->flash->page_size) {
 		if (ols->verbose)
@@ -462,7 +462,7 @@ int OLS_FlashWrite(struct ols_t *ols, uint16_t page, uint8_t *buf)
 		return -2;
 	}
 
-	res = serial_read(ols->fd, &status, 1);
+	res = serial_read(ols->fd, &status, 1, 100);
 
 	if (res != 1) {
 		printf("Page writing timeout\n");

--- a/src/serial.c
+++ b/src/serial.c
@@ -98,7 +98,7 @@ int serial_setup(int fd, unsigned long speed)
 	t_opt.c_oflag &= ~(OCRNL | ONLCR);
 	t_opt.c_oflag &= ~OPOST;
 	t_opt.c_cc[VMIN] = 0;
-	t_opt.c_cc[VTIME] = 10;
+	t_opt.c_cc[VTIME] = 1;
 
 #if IS_DARWIN
 	if( tcsetattr(fd, TCSANOW, &t_opt) < 0 ) {
@@ -141,11 +141,11 @@ int serial_write(int fd, const char *buf, int size)
 	return ret;
 }
 
-int serial_read(int fd, char *buf, int size)
+int serial_read(int fd, char *buf, int size, int timeout)
 {
 	int len = 0;
 	int ret = 0;
-	int timeout = 0;
+
 #if IS_WIN32
 	HANDLE hCom = (HANDLE)fd;
 	unsigned long bread = 0;
@@ -167,9 +167,9 @@ int serial_read(int fd, char *buf, int size)
 		}
 
 		if (ret == 0) {
-			timeout++;
+			timeout--;
 
-			if (timeout >= 10)
+			if (timeout <= 0)
 				break;
 
 			continue;

--- a/src/serial.h
+++ b/src/serial.h
@@ -55,7 +55,7 @@ typedef long speed_t;
 
 int serial_setup(int fd, unsigned long speed);
 int serial_write(int fd, const char *buf, int size);
-int serial_read(int fd, char *buf, int size);
+int serial_read(int fd, char *buf, int size, int timeout);
 int serial_open(const char *port);
 int serial_close(int fd);
 


### PR DESCRIPTION
This fixes the problem with `Error - unknown flash type (48 01 46 03)`. The problem comes when some other process (such as ModemManager) has written to the /dev/ttyACM device and the device is waiting for the remainder of a command packet.

Initialising the OLS device now sends 0x00 bytes up to 7 times until it sees a valid response from the OLS.
